### PR TITLE
Changed binding directive color in base.less

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -35,7 +35,7 @@
             color: #a6e22b;         // Comparisons are bright green
         }
         &.syntax--bindings {
-            color: #b75b00;         // Rule binding directives are dark orange
+            color: #ff00cc;         // Rule binding directives are hot pink
         }
     }
 


### PR DESCRIPTION
Syntax highlighting color for binding directives was changed to hot pink (#ff00cc)